### PR TITLE
Fix: Allow to exclude file names

### DIFF
--- a/src/Filter/ExcludePaths.php
+++ b/src/Filter/ExcludePaths.php
@@ -40,7 +40,7 @@ final class ExcludePaths extends \FilterIterator
         $filePath = $file->getRealPath();
 
         foreach ($this->excludePaths as $excludePath) {
-            if (0 === \strpos($filePath, $excludePath . '/')) {
+            if ($excludePath === $filePath || 0 === \strpos($filePath, $excludePath . '/')) {
                 return false;
             }
         }

--- a/tests/Filter/ExcludePathsTest.php
+++ b/tests/Filter/ExcludePathsTest.php
@@ -122,4 +122,36 @@ final class ExcludePathsTest extends TestCase
         $this->assertContainsOnlyInstancesOf(\SplFileInfo::class, $iterated);
         $this->assertEquals($expectedFilePaths, $iterated);
     }
+
+    public function testIterateFiltersElementsWhichAreInOrEqualExcludedPaths(): void
+    {
+        $expectedFilePaths = [
+            \realpath(__DIR__ . '/../_fixture/Foo/Bar.php'),
+            \realpath(__DIR__ . '/../_fixture/Bar.php'),
+        ];
+
+        $excludedFilePaths = [
+            __DIR__ . '/../_fixture/Foo.php',
+            __DIR__ . '/../_fixture/Bar/Baz.php',
+        ];
+
+        $files = \array_map(function (string $path): \SplFileInfo {
+            return new \SplFileInfo($path);
+        }, \array_merge($expectedFilePaths, $excludedFilePaths));
+
+        $iterator = new \ArrayIterator($files);
+
+        $filter = new ExcludePaths(
+            $iterator,
+            [
+                __DIR__ . '/../_fixture/Foo.php',
+                __DIR__ . '/../_fixture/Bar',
+            ]
+        );
+
+        $iterated = \iterator_to_array($filter);
+
+        $this->assertContainsOnlyInstancesOf(\SplFileInfo::class, $iterated);
+        $this->assertEquals($expectedFilePaths, $iterated);
+    }
 }


### PR DESCRIPTION
This PR

* [x] allows to exclude file names

Follows #7.