### PR TITLE
Fix: Turn file finder into iterator

### DIFF
--- a/src/Finder/File.php
+++ b/src/Finder/File.php
@@ -12,26 +12,45 @@ declare(strict_types=1);
 
 namespace SebastianBergmann\FileIterator\Finder;
 
-final class File implements \IteratorAggregate
+final class File implements \Iterator
 {
     /**
      * @var string
      */
     private $path;
 
+    /**
+     * @var bool
+     */
+    private $hasIterated = false;
+
     public function __construct(string $path)
     {
         $this->path = $path;
     }
 
-    public function getIterator(): \ArrayIterator
+    public function current(): \SplFileInfo
     {
-        if (!\file_exists($this->path)) {
-            return new \ArrayIterator();
-        }
+        return new \SplFileInfo($this->path);
+    }
 
-        return new \ArrayIterator([
-            new \SplFileInfo($this->path),
-        ]);
+    public function next(): void
+    {
+        $this->hasIterated = true;
+    }
+
+    public function key()
+    {
+        return $this->path;
+    }
+
+    public function valid(): bool
+    {
+        return !$this->hasIterated && \file_exists($this->path);
+    }
+
+    public function rewind(): void
+    {
+        $this->hasIterated = false;
     }
 }

--- a/tests/Finder/FileTest.php
+++ b/tests/Finder/FileTest.php
@@ -25,23 +25,50 @@ final class FileTest extends TestCase
 
         $finder = new File($path);
 
-        $iterated = \iterator_to_array($finder);
+        $iterated = \iterator_to_array(
+            $finder,
+            false
+        );
 
         $this->assertCount(0, $iterated);
     }
 
-    public function testIterateWhenFileExists(): void
+    public function testIterateWhenFileExistsWithoutKeys(): void
     {
         $path = __FILE__;
 
         $finder = new File($path);
 
-        $iterated = \iterator_to_array($finder);
+        $iterated = \iterator_to_array(
+            $finder,
+            false
+        );
 
         $this->assertCount(1, $iterated);
         $this->assertContainsOnlyInstancesOf(\SplFileInfo::class, $iterated);
 
         $file = \array_shift($iterated);
+
+        $this->assertSame($path, $file->getRealPath());
+    }
+
+    public function testIterateWhenFileExistsWithKeys(): void
+    {
+        $path = __FILE__;
+
+        $finder = new File($path);
+
+        $iterated = \iterator_to_array(
+            $finder,
+            true
+        );
+
+        $this->assertCount(1, $iterated);
+        $this->assertContainsOnlyInstancesOf(\SplFileInfo::class, $iterated);
+        $this->assertArrayHasKey($path, $iterated);
+
+        /** @var \SplFileInfo $file */
+        $file = $iterated[$path];
 
         $this->assertSame($path, $file->getRealPath());
     }


### PR DESCRIPTION
This PR

* [x] turns the file finder into an iterator

Reverts 6d2404cf192a514089672016ad24097ba89c7ca1.